### PR TITLE
Added Electron asar support (fixes issue #75)

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -121,6 +121,29 @@ query();
 >
 > Recommended use `Microsoft.ACE.OLEDB.12.0`, download: [Microsoft.ACE.OLEDB.12.0](https://www.microsoft.com/en-us/download/details.aspx?id=13255)
 
+### Electron
+
+If you want to use this module in an electron app running from an asar package you'll need to make some changes.
+
+1. Move `adodb.js` outside the asar package (in this example I use electron-builder, the `extraResources` option can move the file outside the asar package)
+```json
+"extraResources": [
+  {
+    "from": "./node_modules/node-adodb/lib/adodb.js",
+    "to": "adodb.js"
+  }
+]
+```
+
+2. Tell the module where to find `adodb.js` while running from an asar package (I added this in electron's `main.js` file)
+```javascript
+if(process.mainModule.filename.indexOf('app.asar') !== -1) // Are we running from inside an asar package?
+{
+  process.env.ADODB_JS = './resources/adodb.js'; // In that case we need to set the correct path to adodb.js
+}
+```
+
+
 [npm-image]: https://img.shields.io/npm/v/node-adodb.svg?style=flat-square
 [npm-url]: https://www.npmjs.org/package/node-adodb
 [download-image]: https://img.shields.io/npm/dm/node-adodb.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ query();
 
 ### Electron
 
-See [English readme](README-EN.MD)
+See [English readme](README-EN.md)
 
 [npm-image]: https://img.shields.io/npm/v/node-adodb.svg?style=flat-square
 [npm-url]: https://www.npmjs.org/package/node-adodb

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ query();
 >
 > 推荐使用 `Microsoft.ACE.OLEDB.12.0`，获取地址： [Microsoft.ACE.OLEDB.12.0](https://www.microsoft.com/zh-CN/download/details.aspx?id=13255)
 
+### Electron
+
+See [English readme](README-EN.MD)
+
 [npm-image]: https://img.shields.io/npm/v/node-adodb.svg?style=flat-square
 [npm-url]: https://www.npmjs.org/package/node-adodb
 [download-image]: https://img.shields.io/npm/dm/node-adodb.svg?style=flat-square

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -10,7 +10,7 @@
 const spawn = require('./spawn');
 
 // Get adodb
-const adodb = require.resolve('./adodb');
+const adodb = process.env.ADODB_JS || require.resolve('./adodb');
 
 /**
  * @class Proxy


### PR DESCRIPTION
This PR makes it possible to use `node-adodb` inside a packaged Electron app.

It contains a really small code change and an explanation in the readme on how to use this module with Electron.