### PR TITLE
node-adodb engine does not load x64 provider on Windows x64

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -13,7 +13,7 @@ const path = require('path');
 // Variable
 const archx64 = arch() === 'x64';
 const sysroot = process.env['systemroot'] || process.env['windir'];
-const cscript32 = path.join(sysroot, archx64 ? 'SysWOW64' : 'System32', 'cscript.exe');
+const cscript32 = path.join(sysroot, archx64 ? 'System32' : 'SysWOW64', 'cscript.exe');
 const cscript64 = path.join(sysroot, 'System32/cscript.exe');
 
 /**


### PR DESCRIPTION
Disregard this pull request

Check issues here : https://github.com/nuintun/node-adodb/issues/106