### PR TITLE
Allow to provide extra options

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,6 +114,22 @@ module.exports = {
   },
 
   /**
+   * @property OPTIONS
+   * @description set ADODB OPTIONS
+   */
+  set OPTIONS(options) {
+	Proxy.options = options;
+  }
+
+  /**
+   * @property OPTIONS
+   * @description Get ADODB OPTIONS
+   */
+  get OPTIONS(options) {
+	return Proxy.options;
+  }
+
+  /**
    * @function open
    * @param {string} connection
    * @param {boolean} [x64]

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -37,7 +37,7 @@ class Proxy {
     const args = [Proxy.adodb, '//E:JScript', '//Nologo', '//U', '//B', command];
 
     // Spawn
-    return spawn(engine, args, params, { encoding: 'utf16le' })
+    return spawn(engine, args, params, Object.assign({ encoding: 'utf16le' }, Proxy.options))
       .then(data => JSON.parse(data))
       .catch(error => {
         if (error.process) {
@@ -51,6 +51,7 @@ class Proxy {
 
 // ADODB actuator
 Proxy.adodb = require.resolve('./adodb');
+Proxy.options = {};
 
 // Exports
 module.exports = Proxy;


### PR DESCRIPTION
In some cases the adodb subprocess lock ups and keep ADO connection open forever. We need to allow to set timeout.

So I added ability to specify options to spawn()